### PR TITLE
Handling different elm versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@
 # Use new container infrastructure to enable caching
 sudo: false
 
-branches:
-  only:
-  - master
 
 # Do not choose a language; we provide our own build tools.
 language: elm

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Handle Elm Project with almost zero effort 🍲.
 - [Why do I chose elm-boil?](#why-do-i-chose-elm-boil)
 
 ## Quickstart
-**Node >= 12.10.0 + Elm >= 0.19.0**
+**Node >= 12.10.0**
 
 ```sh
   npm install -g elm elm-boil

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-boil",
-  "version": "0.0.3",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -964,14 +964,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "elm": {
-      "version": "0.19.1-3",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.1-3.tgz",
-      "integrity": "sha512-6y36ewCcVmTOx8lj7cKJs3bhI5qMfoVEigePZ9PhEUNKpwjjML/pU2u2YSpHVAznuCcojoF6KIsrS1Ci7GtVaQ==",
-      "requires": {
-        "request": "^2.88.0"
-      }
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-boil",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Command Line Utility for creating a boilerplate Elm project easy to run, build and get deployed.",
   "main": "src/index.js",
   "engineStrict": true,

--- a/template/elm.json
+++ b/template/elm.json
@@ -4,7 +4,7 @@
         "src",
         "env"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "<elmVersion>",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.2",


### PR DESCRIPTION
Now elm-boil can handle different elm versions.
If elm is not installed on the local machine, a prompt question asks users if it can proceed with a npm global elm installation.