### PR TITLE
Handle Elm compile errors

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -189,7 +189,7 @@ function perform(operation, path, host, port) {
         if(answer.createIndex) {
           fs.writeFileSync(
             path.join(process.cwd(), 'public', 'index.html'),
-            templates.defaultIndexJs,
+            templates.defaultIndex,
             {
               encoding: 'utf-8'
             }
@@ -218,9 +218,7 @@ function perform(operation, path, host, port) {
  * @param {string} [host="0.0.0.0"] 
  * @param {int} [port=3000]
  */
-function handleServe(host, port) {
-  var host = host || "0.0.0.0";
-  var port = port || 3000;
+function handleServe(host="0.0.0.0", port=3000) {
   var nowTimestamp = new Date().getTime().toString();
   servingPath = tmpPath + nowTimestamp;
   perform(Operations.SERVE, servingPath, host, port);
@@ -231,7 +229,7 @@ function handleServe(host, port) {
  * Creates an optimized Elm build in the specified directory
  * @param {string} [outputDir="dist"]
  */
-function handleBuild(outputDir) {
+function handleBuild(outputDir="dist") {
   log.info("Building project in ./" + outputDir);
   perform(Operations.BUILD, outputDir);
 }

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -32,7 +32,7 @@ function log(message, level) {
   if (color === undefined) {
     color = bColors.UNDERLINE;
   }
-  console.log(`${color}[${formatDate(now)}][${level}]    ${message}${bColors.ENDC}`);
+  console.log(`${color}[${formatDate(now)}][${level}]\t${message}${bColors.ENDC}`);
 }
 
 module.exports.info = function info(message) {


### PR DESCRIPTION
Now the serving procedure handles Elm compile error showing them in the browser with an autoreload.
This is an example:
![photo_2020-01-26_20-10-56](https://user-images.githubusercontent.com/9217515/73140325-fdb4ec80-4077-11ea-8bbf-4c5bf89b71fb.jpg)
